### PR TITLE
Fix other small problems

### DIFF
--- a/Credits.html
+++ b/Credits.html
@@ -80,7 +80,8 @@
 <div class="content">
 
 <section>
-<a class="goto" name="1"><h2>hamburger-menu-svgrepo-com.svg</h2></a>
+<a name="1"></a>
+<h2>hamburger-menu-svgrepo-com.svg</h2>
 <p><a href="https://www.svgrepo.com/svg/361514/hamburger-menu" target="_blank">Source</a></p>
 <p>Licensed under the <a href="https://github.com/radix-ui/icons/blob/main/LICENSE" target="_blank">MIT License</a>, shown below:</p>
 <p>
@@ -109,7 +110,8 @@ SOFTWARE.
 </section>
 
 <section>
-<a class="goto" name="2"><h2>A close up of a book with writing on it photo</h2></a>
+<a name="2"></a>
+<h2>A close up of a book with writing on it photo</h2>
 <p><a href="https://unsplash.com/photos/a-close-up-of-a-book-with-writing-on-it-_EeTOgrsQTg" target="_blank">Source</a></p>
 <p>By <a href="https://unsplash.com/@mark_casey1976" target="_blank">Mark Casey</a></p>
 <p>Licensed under the <a href="https://unsplash.com/license" target="_blank">Unsplash License</a>, shown below:</p>

--- a/Records/Richard1580Will.html
+++ b/Records/Richard1580Will.html
@@ -168,8 +168,8 @@ The eldest son Thomas was not mentioned in the will nor did he need to be. He wa
 </section>
 
 <hr>
-<section>
-<figure> <!-- This is proabably gonna require more work. I'm not satisfied with the layout between mobile and laptop/desktop -->
+<section class="show-figure">
+<figure>
 <img src="../resource/oldhandwriting.jpg" alt="Close up photo of handwriting in a book">
 <figcaption>This is just a photo of a book with handwriting in it. <br> <a href="../Credits.html#2">Photo by Mark Casey.</a></figcaption>
 </figure>

--- a/Records/Richard1580Will.html
+++ b/Records/Richard1580Will.html
@@ -130,8 +130,8 @@ Which translates as: <br><br>
 On the same day and place [April 18, 1580, at the Chapter House], Agnes Cullen, widow of the said deceased, renounced the execution of this present testament in the Chapter House etc. before the aforementioned Master Thomas Wethered, Canon Residentiary etc.
 </p>
 
-<i>Source: DGS#: 8073104, Register of Wills 1567-1592, Image#: 111/277</i> <br>
-<i>Original record digitized by <a href="https://www.familysearch.org/" target="_blank">Family Search</a>, a non-profit organization sponsored by The Church of Jesus Christ of Latter-day Saints</i>
+<cite>Source: DGS#: 8073104, Register of Wills 1567-1592, Image#: 111/277</cite> <br><br>
+<cite>Original record digitized by <a href="https://www.familysearch.org/" target="_blank">Family Search</a>, a non-profit organization sponsored by The Church of Jesus Christ of Latter-day Saints</cite>
 </div>
 </section>
 

--- a/styles/style.css
+++ b/styles/style.css
@@ -185,10 +185,15 @@ nav .dropdownmenu .dropdownlist a {
     font-size: smaller;
 }
 
+.content .show-figure {
+    display: flex;
+    justify-content: center;
+}
+
 .content figure {
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    max-width: min-content;
 }
 
 .content figure img { /* Will have to set a guideline on how large these images can be */
@@ -246,14 +251,6 @@ footer a {
     nav .dropdownmenu .dropdownlist a {
         font-size: 0.82rem;
     }
-
-/* ================================= */
-/* ============ CONTENT ============ */
-/* ================================= */
-
-    .content figure {
-        align-items: center;
-    }
 }
 
 @media (min-width: 481px) and (max-width: 768px) { /* ------ NORMAL SIZED PHONES ------ */
@@ -286,10 +283,6 @@ footer a {
         margin: 1em 15%;
     }
 
-    .content figure {
-        align-items: center;
-    }
-
     .content figure img { /* Will have to set a guideline on how large these images can be */
         max-height: 700px;
         max-width: 460px;
@@ -311,10 +304,6 @@ footer a {
 
     .content {
         margin: 1em 12%;
-    }
-
-    .content figure {
-        align-items: center;
     }
 
     .content figure img { /* Will have to set a guideline on how large these images can be */
@@ -367,10 +356,6 @@ footer a {
 
     .content .will-transcription {
         padding: 1em;
-    }
-
-    .content figure {
-        align-items: center;
     }
 
     .content figure img { /* Will have to set a guideline on how large these images can be */
@@ -442,10 +427,6 @@ footer a {
 
     .content .will-transcription {
         padding: 1em;
-    }
-
-    .content figure {
-        align-items: center;
     }
 
     .content figure img { /* Will have to set a guideline on how large these images can be */

--- a/styles/style.css
+++ b/styles/style.css
@@ -124,10 +124,6 @@ nav .dropdownmenu .dropdownlist a {
     font-size: inherit;
 }
 
-.content .goto {
-    color: inherit;
-}
-
 .content a:visited {
     color: #8d3491;
 }


### PR DESCRIPTION
- On Credits.html, a tags no longer wrap around h2 tags, which eliminates the need to change the h2's color in CSS
- On Richard1580Will.html, the figure is always centered on the page, and the caption below will always stick to the start and never overflow past the width of the image. Thank you [Jeff Bridgforth](https://jeffbridgforth.com/having-figure-match-width-of-contained-image/)
- Also on Richard1580Will.html, the i tags at the bottom of the will transcription have been changed to cite tags, and an extra br tag was added to improve readability